### PR TITLE
fix(distrib): add gpsd debian dependency

### DIFF
--- a/distrib/deb/control/control
+++ b/distrib/deb/control/control
@@ -2,7 +2,7 @@ Package: [[package.name]]
 Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
-Depends: kura-core (>= 6.0.0~), kura-core(<< 7.0.0~)
+Depends: kura-core (>= 6.0.0~), kura-core(<< 7.0.0~), gpsd
 Suggests: kura-networking (>= 3.0.0~), kura-networking(<< 4.0.0~)
 Architecture: [[deb.architecture]]
 Maintainer: Eclipse Kura Developers <kura-dev@eclipse.org>


### PR DESCRIPTION
This PR adds `gpsd` debian dependency, since it will be removed from `kura-core`