### PR TITLE
ci: Added tests folder to exclusions

### DIFF
--- a/.jenkins/ci.groovy
+++ b/.jenkins/ci.groovy
@@ -7,7 +7,7 @@ node {
             enable: true,
             projectKey: "eclipse-kura_kura-position",
             tokenId: "sonarcloud-token-kura-position",
-            exclusions: "**/*.xml,**/*.yml",
+            exclusions: "tests/**/*,**/*.xml,**/*.yml",
             testExclusions: "**/*"
         ],
     )


### PR DESCRIPTION
This pull request updates the SonarCloud configuration in the Jenkins CI pipeline to exclude the `tests` directory from analysis, in addition to the previously excluded XML and YAML files.

Configuration update:

* Updated the `exclusions` parameter in the SonarCloud configuration within `.jenkins/ci.groovy` to also exclude all files under the `tests` directory from analysis.