### PR TITLE
build: skipping bundles pom generation in tycho-packaging-plugin

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -85,8 +85,7 @@
                     <artifactId>tycho-packaging-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <configuration>
-                        <strictVersions>true</strictVersions>
-                        <deriveHeaderFromSource>false</deriveHeaderFromSource>
+                        <skipPomGeneration>true</skipPomGeneration>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Deployed artifacts contain wrong path autogenerated by the tycho-packaging-plugin, preventing correct build in other bundles. This PR fixes the problem